### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,6 @@
 name: Docker Image CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/jamesmoore/docker-megacmd/security/code-scanning/1](https://github.com/jamesmoore/docker-megacmd/security/code-scanning/1)

The best way to fix this issue is to add an explicit `permissions` key to the workflow to limit the `GITHUB_TOKEN` permissions used by the job. Since this workflow is focused on building and publishing Docker images, and leveraging GitHub-provided `GITHUB_TOKEN` for authentication with the registry, the minimal required permission is usually `contents: read` in most cases. If additional write privileges are needed (for example, writing to packages), they should be granted only as necessary. In this fix, we will add `permissions: contents: read` at the root of the workflow (right after the `name` line and before the `on`). This makes the entire workflow default to `contents: read`, and specific jobs can override if needed. No changes to steps, fields, or structure are needed beyond this.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
